### PR TITLE
Add socials section

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -52,6 +52,7 @@
 	},
 	"Rebrand": {
 		"eventBanner": "Join BioHack",
+		"followUs": "Follow us",
 		"learnMore": "Learn more about BioHack",
 		"message": "Our new design is on the way. This page isn't ready for public eyes.",
 		"soon": "Check back soon",

--- a/messages/es.json
+++ b/messages/es.json
@@ -52,6 +52,7 @@
 	},
 	"Rebrand": {
 		"eventBanner": "Únete a BioHack",
+		"followUs": "Síguenos",
 		"learnMore": "Conocé más sobre BioHack",
 		"message": "Nuestro nuevo diseño está en camino. Esta página aún no está lista para el público.",
 		"soon": "Vuelve pronto",

--- a/src/components/RebrandNotice.tsx
+++ b/src/components/RebrandNotice.tsx
@@ -1,6 +1,18 @@
+import { Instagram, Linkedin } from "lucide-react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
+import type { SVGProps } from "react";
 import { Countdown } from "@/components/Countdown";
+import { Button } from "@/components/ui/button";
+
+function TiktokIcon(props: SVGProps<SVGSVGElement>) {
+	return (
+		<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+			<title>TikTok</title>
+			<path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53 3.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z" />
+		</svg>
+	);
+}
 
 export default function Page() {
 	const t = useTranslations("Rebrand");
@@ -31,6 +43,41 @@ export default function Page() {
 					<p className="text-lg">{t("message")}</p>
 					<p className="font-semibold">{t("tagline")}</p>
 					<p>{t("soon")}</p>
+					<div className="space-y-2">
+						<p className="font-semibold">{t("followUs")}</p>
+						<div className="flex justify-center gap-4">
+							<Button asChild variant="ghost" size="icon">
+								<a
+									href="https://www.instagram.com/404techfound.latam/"
+									aria-label="Instagram"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<Instagram className="size-6" />
+								</a>
+							</Button>
+							<Button asChild variant="ghost" size="icon">
+								<a
+									href="https://www.linkedin.com/company/404techfound/"
+									aria-label="LinkedIn"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<Linkedin className="size-6" />
+								</a>
+							</Button>
+							<Button asChild variant="ghost" size="icon">
+								<a
+									href="https://www.tiktok.com/@404techfound.latam"
+									aria-label="TikTok"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<TiktokIcon className="size-6" />
+								</a>
+							</Button>
+						</div>
+					</div>
 				</div>
 			</div>
 		</>


### PR DESCRIPTION
## Summary
- show Instagram, LinkedIn and TikTok links on the rebrand page
- include translation strings for the new section

## Testing
- `npx biome check messages/en.json messages/es.json src/components/RebrandNotice.tsx`
- `bun run type` *(no output)*
- `bun run test` *(fails: script not found)*
- `bun x lefthook run pre-commit`
- `bun x lefthook run pre-push` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68656299ff508330bf6605dbc8fcfe02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new section to display social media follow links (Instagram, LinkedIn, TikTok) with accessible icons on the rebranding notice page.

* **Localization**
  * Introduced new translation keys for "Follow us" in both English and Spanish to support the new social media section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->